### PR TITLE
Temporary Fix for "Array to String conversion"

### DIFF
--- a/src/Moltin/SDK/SDK.php
+++ b/src/Moltin/SDK/SDK.php
@@ -159,7 +159,14 @@ class SDK
 
             // Format errors
             if (isset($result['errors']) && is_array($result['errors'])) {
-                $error = implode("\n", $result['errors']);
+                
+                /*
+                 * TODO: maybe a custom mapping function would be better
+                 * http://stackoverflow.com/a/6557147/1523417
+                 */
+                // $error = implode("\n", $result['errors']);
+                
+                $error = json_encode($result['errors']);
             } elseif (isset($result['error']) && is_array($result['error'])) {
                 $error = implode("\n", $result['error']);
             } else {


### PR DESCRIPTION
`$result['errors']` seems to be an assoc array. Implode will cause an "Array to String conversion" error.
For now: i fixed it by returning a JSON string
Maybe a custom mapping function would be better as mentioned [here](http://stackoverflow.com/a/6557147/1523417)
As I'm a PHP beginner/idiot I'm sure there are better ways to fix this.