### PR TITLE
Exception Visibility

### DIFF
--- a/src/Moltin/SDK/Exception/Exception.php
+++ b/src/Moltin/SDK/Exception/Exception.php
@@ -12,7 +12,7 @@
 *
 * @package moltin/php-sdk
 * @author Jamie Holdroyd <jamie@molt.in>
-* @copyright 2013 Moltin Ltd.
+* @copyright 2015 Moltin Ltd.
 * @version dev
 * @link http://github.com/moltin/php-sdk
 *
@@ -20,10 +20,6 @@
 
 namespace Moltin\SDK\Exception;
 
-class InvalidAuthenticationRequestException extends \RuntimeException implements Exception
+interface Exception
 {
-    public function __toString()
-    {
-        return $this->message;
-    }
 }

--- a/src/Moltin/SDK/Exception/InvalidFieldTypeException.php
+++ b/src/Moltin/SDK/Exception/InvalidFieldTypeException.php
@@ -20,7 +20,7 @@
 
 namespace Moltin\SDK\Exception;
 
-class InvalidFieldTypeException extends \Exception
+class InvalidFieldTypeException extends \RuntimeException implements Exception
 {
     public function __toString()
     {

--- a/src/Moltin/SDK/Exception/InvalidRequestException.php
+++ b/src/Moltin/SDK/Exception/InvalidRequestException.php
@@ -20,7 +20,7 @@
 
 namespace Moltin\SDK\Exception;
 
-class InvalidRequestException extends \Exception
+class InvalidRequestException extends \RuntimeException implements Exception
 {
     public function __toString()
     {

--- a/src/Moltin/SDK/Exception/InvalidResponseException.php
+++ b/src/Moltin/SDK/Exception/InvalidResponseException.php
@@ -20,7 +20,7 @@
 
 namespace Moltin\SDK\Exception;
 
-class InvalidResponseException extends \Exception
+class InvalidResponseException extends \RuntimeException implements Exception
 {
     public function __toString()
     {


### PR DESCRIPTION
I've added a `Moltin\SDK\Exception\Exception` interface in the library as
this allows clients to catch any Moltin specific Exception raised by
the library.

In addition to this, I've changed the Exceptions to extend `\RuntimeException`
as the Exceptions can only be found during runtime.

There should be no breaking changes.