### PR TITLE
Short Array Syntax

### DIFF
--- a/src/Authenticate/ClientCredentials.php
+++ b/src/Authenticate/ClientCredentials.php
@@ -25,11 +25,11 @@ use Moltin\SDK\Exception\InvalidAuthenticationRequestException as InvalidAuthReq
 
 class ClientCredentials implements \Moltin\SDK\AuthenticateInterface
 {
-    protected $data = array(
+    protected $data = [
         'token'   => null,
         'refresh' => null,
         'expires' => null
-    );
+    ];
 
     public function authenticate($args, \Moltin\SDK\SDK $parent)
     {
@@ -40,11 +40,11 @@ class ClientCredentials implements \Moltin\SDK\AuthenticateInterface
 
         // Variables
         $url  = $parent->url . 'oauth/access_token';
-        $data = array(
+        $data = [
             'grant_type'    => 'client_credentials',
             'client_id'     => $args['client_id'],
             'client_secret' => $args['client_secret']
-        );
+        ];
 
         // Make request
         $parent->request->setup($url, 'POST', $data);
@@ -81,7 +81,7 @@ class ClientCredentials implements \Moltin\SDK\AuthenticateInterface
     protected function validate($args)
     {
         // Variables
-        $required = array('client_id', 'client_secret');
+        $required = ['client_id', 'client_secret'];
         $keys     = array_keys($args);
         $diff     = array_diff($required, $keys);
 

--- a/src/Authenticate/Implicit.php
+++ b/src/Authenticate/Implicit.php
@@ -24,20 +24,20 @@ use Moltin\SDK\Exception\InvalidResponseException as InvalidResponse;
 
 class Implicit implements \Moltin\SDK\AuthenticateInterface
 {
-    protected $data = array(
+    protected $data = [
         'token'   => null,
         'refresh' => null,
         'expires' => null
-    );
+    ];
 
     public function authenticate($args, \Moltin\SDK\SDK $parent)
     {
         // Variables
         $url  = $parent->url . 'oauth/access_token';
-        $data = array(
+        $data = [
             'grant_type' => 'implicit',
             'client_id'  => $args['client_id']
-        );
+        ];
 
         $parent->request->setup($url, 'POST', $data);
         $result = $parent->request->make();

--- a/src/Authenticate/Password.php
+++ b/src/Authenticate/Password.php
@@ -24,24 +24,24 @@ use Moltin\SDK\Exception\InvalidResponseException as InvalidResponse;
 
 class Password implements \Moltin\SDK\AuthenticateInterface
 {
-    protected $data = array(
+    protected $data = [
         'token'   => null,
         'refresh' => null,
         'expires' => null
-    );
+    ];
 
     public function authenticate($args, \Moltin\SDK\SDK $parent)
     {
         // Variables
         $url  = $parent->url . 'oauth/access_token';
-        $data = array(
+        $data = [
             'grant_type'    => 'password',
             'username'      => $args['username'],
             'password'      => $args['password'],
             'client_id'     => $args['client_id'],
             'client_secret' => $args['client_secret'],
             'redirect_uri'  => $args['redirect_uri']
-        );
+        ];
 
         $parent->request->setup($url, 'POST', $data);
         $result = $parent->request->make();

--- a/src/Authenticate/Refresh.php
+++ b/src/Authenticate/Refresh.php
@@ -25,11 +25,11 @@ use Moltin\SDK\Exception\InvalidAuthenticationRequestException as InvalidAuthReq
 
 class Refresh implements \Moltin\SDK\AuthenticateInterface
 {
-    protected $data = array(
+    protected $data = [
         'token'   => null,
         'refresh' => null,
         'expires' => null
-    );
+    ];
 
     public function authenticate($args, \Moltin\SDK\SDK $parent)
     {
@@ -40,12 +40,12 @@ class Refresh implements \Moltin\SDK\AuthenticateInterface
 
         // Variables
         $url  = $parent->url . 'oauth/access_token';
-        $data = array(
+        $data = [
             'grant_type'    => 'refresh_token',
             'client_id'     => $args['client_id'],
             'client_secret' => $args['client_secret'],
             'refresh_token' => $args['refresh_token']
-        );
+        ];
 
         // Make request
         $parent->request->setup($url, 'POST', $data);
@@ -77,7 +77,7 @@ class Refresh implements \Moltin\SDK\AuthenticateInterface
     protected function validate($args)
     {
         // Variables
-        $required = array('client_id', 'client_secret', 'refresh_token');
+        $required = ['client_id', 'client_secret', 'refresh_token'];
         $keys     = array_keys($args);
         $diff     = array_diff($required, $keys);
 

--- a/src/Facade/Address.php
+++ b/src/Facade/Address.php
@@ -44,12 +44,12 @@ class Address
 		return self::$sdk->put('customers/'.$customer.'/addresses/'.$id, $data);
 	}
 
-	public static function Find($customer, $terms = array())
+	public static function Find($customer, $terms = [])
 	{
 		return self::$sdk->get('customers/'.$customer.'/addresses', $terms);
 	}
 
-	public static function Listing($customer, $terms = array())
+	public static function Listing($customer, $terms = [])
 	{
 		return self::$sdk->get('customers/'.$customer.'/addresses', $terms);
 	}

--- a/src/Facade/Cache.php
+++ b/src/Facade/Cache.php
@@ -29,7 +29,7 @@ class Cache
 		self::$sdk = $sdk;
 	}
 
-	public static function Listing($data = array())
+	public static function Listing($data = [])
 	{
 		return self::$sdk->get('cache', $data);
 	}

--- a/src/Facade/Cart.php
+++ b/src/Facade/Cart.php
@@ -43,11 +43,11 @@ class Cart
 
 	public static function Insert($id, $qty = 1, $mods = null)
 	{
-		return self::$sdk->post('carts/'.self::$identifier, array(
+		return self::$sdk->post('carts/'.self::$identifier, [
 			'id'       => $id,
 			'quantity' => $qty,
 			'modifier' => $mods
-		));
+		]);
 	}
 
 	public static function Update($id, $data)
@@ -80,7 +80,7 @@ class Cart
 		return self::$sdk->get('carts/'.self::$identifier.'/checkout');
 	}
 
-	public static function Order($data = array())
+	public static function Order($data = [])
 	{
 		return self::$sdk->post('carts/'.self::$identifier.'/checkout', $data);
 	}
@@ -95,7 +95,7 @@ class Cart
 		return self::$sdk->post('carts/'.self::$identifier.'/discount', ['code' => $code]);
 	}
 
-	public static function Listing($terms = array())
+	public static function Listing($terms = [])
 	{
 		return self::$sdk->get('carts', $terms);
 	}

--- a/src/Facade/Category.php
+++ b/src/Facade/Category.php
@@ -27,7 +27,7 @@ class Category
 	protected static $single = 'categories';
 	protected static $plural = 'categories';
 
-	public static function Tree($terms = array())
+	public static function Tree($terms = [])
 	{
 		return self::$sdk->get(self::$plural.'/tree', $terms);
 	}

--- a/src/Facade/Checkout.php
+++ b/src/Facade/Checkout.php
@@ -29,7 +29,7 @@ class Checkout
 		self::$sdk = $sdk;
 	}
 
-	public static function Payment($method, $order, $data = array())
+	public static function Payment($method, $order, $data = [])
 	{
 		return self::$sdk->post('checkout/payment/'.$method.'/'.$order, $data);
 	}

--- a/src/Facade/Email.php
+++ b/src/Facade/Email.php
@@ -34,7 +34,7 @@ class Email
 		return self::$sdk->get('emails/'.$slug);
 	}
 
-	public static function Listing($terms = array())
+	public static function Listing($terms = [])
 	{
 		return self::$sdk->get('emails', $terms);
 	}

--- a/src/Facade/Entry.php
+++ b/src/Facade/Entry.php
@@ -34,12 +34,12 @@ class Entry
 		return self::$sdk->get('flows/'.$flow.'/entries/'.$id);
 	}
 
-	public static function Find($flow, $terms = array())
+	public static function Find($flow, $terms = [])
 	{
 		return self::$sdk->get('flows/'.$flow.'/entries/search', $terms);
 	}
 
-	public static function Listing($flow = null, $terms = array())
+	public static function Listing($flow = null, $terms = [])
 	{
 		return self::$sdk->get('flows/'.$flow.'/entries', $terms);
 	}	

--- a/src/Facade/Flow.php
+++ b/src/Facade/Flow.php
@@ -34,7 +34,7 @@ class Flow
 		return self::$sdk->get('flows/'.$slug);
 	}
 
-	public static function Listing($terms = array())
+	public static function Listing($terms = [])
 	{
 		return self::$sdk->get('flows', $terms);
 	}
@@ -54,7 +54,7 @@ class Flow
 		return self::$sdk->fields('flows', $slug);
 	}
 
-	public static function Entries($slug = null, $terms = array())
+	public static function Entries($slug = null, $terms = [])
 	{
 		return self::$sdk->get('flows/'.$slug.'/entries', $terms);
 	}

--- a/src/Facade/Moltin.php
+++ b/src/Facade/Moltin.php
@@ -22,7 +22,7 @@ namespace Moltin\SDK\Facade;
 
 class Moltin
 {
-	protected static $methods = array('ClientCredentials', 'Password', 'Refresh');
+	protected static $methods = ['ClientCredentials', 'Password', 'Refresh'];
 	protected static $sdk;
 
 	public static function init(\Moltin\SDK\SDK $sdk)
@@ -30,7 +30,7 @@ class Moltin
 		self::$sdk = $sdk;
 	}
 
-	public static function Authenticate($method, $data = array(), $extra = array())
+	public static function Authenticate($method, $data = [], $extra = [])
 	{
 		if ( self::$sdk === null ) {
 			self::$sdk = new \Moltin\SDK\SDK(new \Moltin\SDK\Storage\Session(), new \Moltin\SDK\Request\CURL(), $extra);
@@ -40,22 +40,22 @@ class Moltin
 		return self::$sdk->authenticate(new $method(), $data);
 	}
 
-	public static function Get($uri, $data = array())
+	public static function Get($uri, $data = [])
 	{
 		return self::$sdk->get($uri, $data);
 	}
 
-	public static function Post($uri, $data = array())
+	public static function Post($uri, $data = [])
 	{
 		return self::$sdk->post($uri, $data);
 	}
 
-	public static function Put($uri, $data = array())
+	public static function Put($uri, $data = [])
 	{
 		return self::$sdk->put($uri, $data);
 	}
 
-	public static function Delete($uri, $data = array())
+	public static function Delete($uri, $data = [])
 	{
 		return self::$sdk->delete($uri, $data);
 	}

--- a/src/Facade/Payment.php
+++ b/src/Facade/Payment.php
@@ -29,42 +29,42 @@ class Payment
 		self::$sdk = $sdk;
 	}
 
-	public static function Authorize($order, $data = array())
+	public static function Authorize($order, $data = [])
 	{
 		return self::Process('authorize', $order, $data);
 	}
 
-	public static function CompleteAuthorize($order, $data = array())
+	public static function CompleteAuthorize($order, $data = [])
 	{
 		return self::Process('complete_authorize', $order, $data);
 	}
 
-	public static function Capture($order, $data = array())
+	public static function Capture($order, $data = [])
 	{
 		return self::Process('capture', $order, $data);
 	}
 
-	public static function Purchase($order, $data = array())
+	public static function Purchase($order, $data = [])
 	{
 		return self::Process('purchase', $order, $data);
 	}
 
-	public static function CompletePurchase($order, $data = array())
+	public static function CompletePurchase($order, $data = [])
 	{
 		return self::Process('complete_purchase', $order, $data);
 	}
 
-	public static function Refund($order, $data = array())
+	public static function Refund($order, $data = [])
 	{
 		return self::Process('refund', $order, $data);
 	}
 
-	public static function Void($order, $data = array())
+	public static function Void($order, $data = [])
 	{
 		return self::Process('void', $order, $data);
 	}
 
-	protected static function Process($method, $order, $data = array())
+	protected static function Process($method, $order, $data = [])
 	{
 		return self::$sdk->post('checkout/payment/'.$method.'/'.$order, $data);
 	}

--- a/src/Facade/Product.php
+++ b/src/Facade/Product.php
@@ -27,7 +27,7 @@ class Product
 	protected static $single = 'products';
 	protected static $plural = 'products';
 
-	public static function Search($terms = array())
+	public static function Search($terms = [])
 	{
 		return self::$sdk->get(self::$plural.'/search', $terms);
 	}

--- a/src/Facade/Promotion.php
+++ b/src/Facade/Promotion.php
@@ -27,7 +27,7 @@ class Promotion
 	protected static $single = 'promotions/cart';
 	protected static $plural = 'promotions/cart';
 
-	public static function Search($terms = array())
+	public static function Search($terms = [])
 	{
 		return self::$sdk->get(self::$plural.'/search', $terms);
 	}

--- a/src/Facade/Transaction.php
+++ b/src/Facade/Transaction.php
@@ -34,7 +34,7 @@ class Transaction
 		return self::$sdk->get('transactions/'.$slug);
 	}
 
-	public static function Listing($terms = array())
+	public static function Listing($terms = [])
 	{
 		return self::$sdk->get('transactions', $terms);
 	}

--- a/src/Facade/Webhook.php
+++ b/src/Facade/Webhook.php
@@ -34,7 +34,7 @@ class Webhook
 		return self::$sdk->get('webhooks/'.$id);
 	}
 
-	public static function Listing($terms = array())
+	public static function Listing($terms = [])
 	{
 		return self::$sdk->get('webhooks', $terms);
 	}

--- a/src/FacadeTrait.php
+++ b/src/FacadeTrait.php
@@ -49,12 +49,12 @@ trait FacadeTrait
 		return self::$sdk->delete(self::$single.'/'.$id);
 	}
 
-	public static function Find($terms = array())
+	public static function Find($terms = [])
 	{
 		return self::$sdk->get(self::$single.'', $terms);
 	}
 
-	public static function Listing($terms = array())
+	public static function Listing($terms = [])
 	{
 		return self::$sdk->get(self::$plural, $terms);
 	}

--- a/src/Flows.php
+++ b/src/Flows.php
@@ -43,14 +43,14 @@ class Flows
             }
 
                 // Setup args
-            $this->args = array(
+            $this->args = [
                 'name' => $field['slug'],
                 'id' => $field['slug'],
                 'value' => (isset($_POST[$field['slug']]) ? $_POST[$field['slug']] : (isset($field['value']) ? $field['value'] : null)),
                 'required' => ($field['required'] == 1 ? 'required' : false),
                 'class' => ['form-control'],
                 'data-fieldtype' => $field['type'],
-            );
+            ];
 
             // WYSIWYG argument
             if (isset($field['options']['wysiwyg']) && $field['options']['wysiwyg'] == 1) {

--- a/src/Request/CURL.php
+++ b/src/Request/CURL.php
@@ -30,7 +30,7 @@ class CURL implements \Moltin\SDK\RequestInterface
 
     protected $curl;
 
-    public function setup($url, $method, $post = array(), $token = null)
+    public function setup($url, $method, $post = [], $token = null)
     {
         // Variables
         $headers      = [];
@@ -39,7 +39,7 @@ class CURL implements \Moltin\SDK\RequestInterface
         $this->method = $method;
 
         // Add request settings
-        curl_setopt_array($this->curl, array(
+        curl_setopt_array($this->curl, [
             CURLOPT_URL            => $url,
             CURLOPT_CUSTOMREQUEST  => $method,
             CURLOPT_HEADER         => false,
@@ -49,7 +49,7 @@ class CURL implements \Moltin\SDK\RequestInterface
             CURLOPT_SSL_VERIFYPEER => false,
             CURLOPT_TIMEOUT        => 40,
             CURLINFO_HEADER_OUT    => true
-        ));
+        ]);
 
         // Add post
         if ( ! empty($post)) {

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -22,7 +22,7 @@ namespace Moltin\SDK;
 
 interface RequestInterface
 {
-    public function setup($token, $url, $method, $post = array());
+    public function setup($token, $url, $method, $post = []);
 
     public function make();
 }

--- a/src/SDK.php
+++ b/src/SDK.php
@@ -31,7 +31,7 @@ class SDK
     public $auth_url = 'http://auth.molt.in/';
 
     // Variables
-    public $methods = array('GET', 'POST', 'PUT', 'DELETE');
+    public $methods = ['GET', 'POST', 'PUT', 'DELETE'];
     public $currency;
     public $language;
     public $store;
@@ -42,7 +42,7 @@ class SDK
     protected $refresh;
     protected $expires;
 
-    public function __construct(\Moltin\SDK\StorageInterface $store, \Moltin\SDK\RequestInterface $request, $args = array())
+    public function __construct(\Moltin\SDK\StorageInterface $store, \Moltin\SDK\RequestInterface $request, $args = [])
     {
         // Make global
         $this->store   = $store;
@@ -64,7 +64,7 @@ class SDK
         $this->_registerFacades();
     }
 
-    public function authenticate(\Moltin\SDK\AuthenticateInterface $auth, $args = array())
+    public function authenticate(\Moltin\SDK\AuthenticateInterface $auth, $args = [])
     {
         // Skip active auth or refresh current
         if ($this->expires > 0 and $this->expires > time()) {
@@ -82,7 +82,7 @@ class SDK
         return ($this->token === null ? false : true);
     }
 
-    public function refresh($args = array())
+    public function refresh($args = [])
     {
         // Perform refresh
         $refresh = new Authenticate\Refresh();
@@ -94,25 +94,25 @@ class SDK
         return ($this->token === null ? false : true);
     }
 
-    public function get($uri, $data = array())
+    public function get($uri, $data = [])
     {
         $url = $this->url.$this->version.'/'.$uri;
         return $this->_request($url, 'GET', $data);
     }
 
-    public function post($uri, $data = array())
+    public function post($uri, $data = [])
     {
         $url = $this->url.$this->version.'/'.$uri;
         return $this->_request($url, 'POST', $data);
     }
 
-    public function put($uri, $data = array())
+    public function put($uri, $data = [])
     {
         $url = $this->url.$this->version.'/'.$uri;
         return $this->_request($url, 'PUT', $data);
     }
 
-    public function delete($uri, $data = array())
+    public function delete($uri, $data = [])
     {
         $url = $this->url.$this->version.'/'.$uri;
         return $this->_request($url, 'DELETE', $data);
@@ -200,7 +200,7 @@ class SDK
         // Append URL
         if ($method == 'GET' and ! empty($data)) {
             $url .= '?' . http_build_query($data);
-            $data = array();
+            $data = [];
         } else if ($method == 'PUT') {
             $url .= (strpos($url, '?') !== false ? '&' : '?').'_method='.$method;
             $method = 'POST';

--- a/src/Storage/Runtime.php
+++ b/src/Storage/Runtime.php
@@ -22,7 +22,7 @@ namespace Moltin\SDK\Storage;
 
 class Runtime implements \Moltin\SDK\StorageInterface
 {
-    protected $items = array();
+    protected $items = [];
 
     /**
      * Creates session or respawns previous instance, also created the default
@@ -30,11 +30,11 @@ class Runtime implements \Moltin\SDK\StorageInterface
      *
      * @param array [$args] Optional array of arguments
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         // Create default item
         if (! isset($this->items)) {
-            $this->items = array();
+            $this->items = [];
         }
     }
 

--- a/src/Storage/Session.php
+++ b/src/Storage/Session.php
@@ -28,13 +28,13 @@ class Session implements \Moltin\SDK\StorageInterface
      *
      * @param array [$args] Optional array of arguments
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         session_id() or session_start();
 
         // Create default item
         if ( ! isset($_SESSION['sdk'])) {
-            $_SESSION['sdk'] = array();
+            $_SESSION['sdk'] = [];
         }
     }
 

--- a/src/StorageInterface.php
+++ b/src/StorageInterface.php
@@ -22,7 +22,7 @@ namespace Moltin\SDK;
 
 interface StorageInterface
 {
-    public function __construct($args = array());
+    public function __construct($args = []);
 
     public function get($id);
 


### PR DESCRIPTION
As we're requiring >= PHP 5.4, we may as well use the
short array syntax.

Saves a few key presses. :smile: 