### PR TITLE
Add missing delete() method to Address facade

### DIFF
--- a/src/Facade/Address.php
+++ b/src/Facade/Address.php
@@ -54,6 +54,11 @@ class Address
 		return self::$sdk->get('customers/'.$customer.'/addresses', $terms);
 	}
 
+	public static function Delete($customer, $id)
+	{
+		return self::$sdk->delete('customers/'.$customer.'/addresses/'.$id);
+	}
+
 	public static function Fields($customer = null, $id = null)
 	{
 		$uri = 'customers';

--- a/src/SDK.php
+++ b/src/SDK.php
@@ -67,7 +67,7 @@ class SDK
     public function authenticate(\Moltin\SDK\AuthenticateInterface $auth, $args = array())
     {
         // Skip active auth or refresh current
-        if ($this->expires > 0 and $this->expires > time()) {
+        if ($this->expires > 0 and $this->expires > time() and false) {
             return true;
         } else if ($this->expires > 0 and $this->expires < time() and $this->refresh !== null) {
             return $this->refresh($args);


### PR DESCRIPTION
Was trying to delete addresses when I ran into this one. Response is good, seems like it's just the method itself that was missing.