### PR TITLE
Fix typo in v2 Gateway resource class and remove unnecessary namespac…

### DIFF
--- a/src/Resources/Gateways.php
+++ b/src/Resources/Gateways.php
@@ -3,9 +3,8 @@
 namespace Moltin\Resources;
 
 use Moltin\Resource as Resource;
-use Moltin\Exceptions\FileNotFoundException;
 
-class GAteways extends Resource
+class Gateways extends Resource
 {
     public $uri = 'gateways';
 


### PR DESCRIPTION
Fix typo in v2 Gateway resource class and remove unnecessary namespace declaration